### PR TITLE
Update to use SNAPSHOT version of netcdfgenerator library

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -30,16 +30,18 @@ grails.project.dependency.resolution = {
     repositories {
         inherits true
 
+        mavenRepo 'https://jenkins.aodn.org.au/plugin/repository/everything', {
+            updatePolicy 'always'
+        }
         grailsPlugins()
         grailsHome()
         mavenLocal()
         grailsCentral()
         mavenCentral()
-        mavenRepo 'https://jenkins.aodn.org.au/plugin/repository/everything'
     }
 
     dependencies {
-        compile 'au.org.emii:ncdfgenerator:1.0.0'
+        compile 'au.org.emii:ncdfgenerator:1.0.0-SNAPSHOT'
         runtime 'org.postgresql:postgresql:9.3-1101-jdbc41'
         test "org.grails:grails-datastore-test-support:1.0.2-grails-2.4"
     }


### PR DESCRIPTION
As part of this change I made our Jerkins maven repo first (I don't think this
should cause any problems). I am also setting the updatePolicy to ensure it
checks for new versions often enough.
