### PR TITLE
SubsetService tests can use proper mocking again (after fix in library)

### DIFF
--- a/test/unit/au/org/emii/netcdfsubset/SubsetServiceSpec.groovy
+++ b/test/unit/au/org/emii/netcdfsubset/SubsetServiceSpec.groovy
@@ -4,28 +4,18 @@ import au.org.emii.ncdfgenerator.NcdfGenerator
 import grails.test.mixin.TestFor
 import spock.lang.Specification
 import javax.sql.DataSource
-import java.sql.Connection
 
 @TestFor(SubsetService)
 class SubsetServiceSpec extends Specification {
 
     def ncdfGenerator
-    def writeCallCount = 0
     def typeName = "anmn_ts"
     def dataSource
     def cqlFilter = "INTERSECTS()"
     def response = [:] as OutputStream
 
     def setup() {
-        ncdfGenerator = new NcdfGenerator(null, null)
-        ncdfGenerator.metaClass.write = { String typename, String filterExpr, Connection conn, OutputStream os ->
-            assertEquals typeName, typename
-            assertEquals cqlFilter, filterExpr
-            assertEquals dataSource.connection, conn
-            assertEquals response, os
-
-            writeCallCount++
-        }
+        ncdfGenerator = Mock(NcdfGenerator)
         service._getGenerator = {-> ncdfGenerator}
 
         dataSource = Mock(DataSource)
@@ -37,6 +27,6 @@ class SubsetServiceSpec extends Specification {
         service.subset(typeName, cqlFilter, response)
 
         then:
-        assertEquals 1, writeCallCount
+        1 * ncdfGenerator.write(typeName, cqlFilter, dataSource.connection, response)
     }
 }


### PR DESCRIPTION
This reverts a previous change which was to fix a broken test. However, it didn't really fix the thing, it was just an ugly workaround.

The real fix is in the ncdfgenerator project (that's a problem in itself) as https://github.com/aodn/ncdfgenerator/pull/52.
